### PR TITLE
Updates compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,18 +91,26 @@ export CXX=/usr/local/bin/g++-4.7
 
 ### To install
 
-Edit the [Makefile](Makefile) to reflect where you have installed the Eigen
-headers and Boost headers and libraries:
+The [Makefile](Makefile) contains three variables that need to be set according to where you have installed the Eigen
+headers and Boost headers and libraries on your system. The default values for these are: 
    ```
    EIGEN_INC=/usr/local/include/eigen
    BOOST_INC=/usr/local/include/boost
    BOOST_LIB=/usr/local/lib
    ```
-Run make:
+   
+ If your system has these libraries and header files in those locations, you can simply run make:
    ```
    cd flashpca
    make all
    ```
+   
+ If not, you can override their values on the make command line. For example, if you have the Eigen source in `/opt/eigen-3.2.5` and Boost 1.59.0 installed into `/opt/boost-1.59.0`, you could run: 
+   ```
+   cd flashpca
+   make all EIGEN_INC=/opt/eigen-3.2.5 BOOST_INC=/opt/boost-1.59.0/include BOOST_LIB=/opt/boost-1.59.0/lib
+   ```
+ 
 Note: the compilation process will first look for a local directory named
 Eigen. It should contain the file signature_of_eigen3_matrix_library. Next,
 it will look for the directory /usr/include/eigen3 (Debian/Ubuntu location


### PR DESCRIPTION
Suggests passing values of compile-time variables on the `make` command line rather than editing the `Makefile`. This avoids constantly having git conflicts when attempting to checkout new versions of a cloned source tree. 