### PR TITLE
Allow to project single sample (or small number of samples)

### DIFF
--- a/flashpca.cpp
+++ b/flashpca.cpp
@@ -621,7 +621,7 @@ int main(int argc, char * argv[])
       // see
       // http://yixuan.cos.name/spectra/doc/classSpectra_1_1SymEigsSolver.html
       unsigned int max_dim = (fminl(data.N, data.nsnps) - 1) / 2.0;
-      if(n_dim > max_dim)
+      if(mode != MODE_PREDICT_PCA && n_dim > max_dim)
       {
 				std::cerr << "Error: You asked for " << n_dim << " dimensions, but only " << max_dim << "allowed" << std::endl;
 				return EXIT_FAILURE;


### PR DESCRIPTION
Currently it is impossible to project a single sample (or small number of samples) onto previously calculated pca loadings, because a check is performed to ensure that there is enough data being input to perform pca, which should not be necessary when simply performing a projection.  This PR fixes this by disabling the check when only projecting.

I also suspect there _may_ be a small bug in `RandomPCA::project` with respect to the selected divisor.  When projecting new samples onto previously calculated loadings, if running in `div=DIVISOR_N1` mode, it appears that the divisor used refers to the number of samples in the new set (being projected), as opposed to using the number of samples used to produce the original loading.  However, as this did not pertain to my use case, I didn't investigate any further beyond feeling suspicious.  